### PR TITLE
Test whether a member is a Template

### DIFF
--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -125,7 +125,11 @@ unittest
 template isField(alias T)
 {
     enum isField = (function() {
-        return (!isSomeFunction!(T) && !__traits(isTemplate, T));
+        // isTemplate is relatively new only use it if it exists
+        static if (__traits(compiles, __traits(isTemplate, T)))
+            return (!isSomeFunction!(T) && !__traits(isTemplate, T));
+        else
+            return (!isSomeFunction!(T));
     })();
 }
 
@@ -141,9 +145,12 @@ unittest
     S s;
     static assert( !isField!(s.property) );
     static assert( !isField!(s.func) );
-    static assert( !isField!(s.tmplt) );
-    static assert( !isSomeFunction!(s.tmplt) );
-    static assert( __traits(isTemplate,s.tmplt) );
+
+    static if (__traits(compiles, __traits(isTemplate, T)))
+    {
+        static assert( !isField!(s.tmplt) );
+        static assert( !isSomeFunction!(s.tmplt) );
+    }
 
     static assert( isField!(s.field) );
 }

--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -129,7 +129,7 @@ template isFieldOrProperty(alias T)
         {
             return (functionAttributes!(T) & FunctionAttribute.property);
         }
-        else return true;
+        else return (!__traits(isTemplate, T));
     })();
 }
 

--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -122,14 +122,25 @@ unittest
     static assert(getAnnotation!(anyy, AnyBarUDA).data == 1);
 }
 
+template isField(alias T)
+{
+    enum isField = (function() {
+        return (!isSomeFunction!(T) && !__traits(isTemplate, T));
+    })();
+}
+
 template isFieldOrProperty(alias T)
 {
     enum isFieldOrProperty = (function() {
-        static if (isSomeFunction!(T))
+        static if (isField!(T))
+        {
+            return true;
+        } 
+        else static if (isSomeFunction!(T))
         {
             return (functionAttributes!(T) & FunctionAttribute.property);
-        }
-        else return (!__traits(isTemplate, T));
+        } else 
+            return false;
     })();
 }
 

--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -135,24 +135,30 @@ template isField(alias T)
 
 unittest
 {
-    struct S {
+    struct Foo {
         @property auto property() { return 1.0; }
         auto func() { return 1.0; }
         auto tmplt()() {return 1.0; }
         auto field = 0;
     }
 
-    S s;
-    static assert( !isField!(s.property) );
-    static assert( !isField!(s.func) );
+    static assert( !isField!(Foo.property) );
+    static assert( !isField!(Foo.func) );
 
-    static if (__traits(compiles, __traits(isTemplate, T)))
+    static if (__traits(compiles, __traits(isTemplate, Foo.tmplt)))
     {
-        static assert( !isField!(s.tmplt) );
-        static assert( !isSomeFunction!(s.tmplt) );
+        static assert( !isField!(Foo.tmplt) );
+        static assert( !isSomeFunction!(Foo.tmplt) );
     }
 
-    static assert( isField!(s.field) );
+    static assert( isField!(Foo.field) );
+
+    // Make sure the struct behaves as expected
+    Foo foo;
+    assert( foo.property == 1.0 );
+    assert( foo.func() == 1.0 );
+    assert( foo.tmplt() == 1.0 );
+    assert( foo.field == 0.0 );
 }
 
 template isFieldOrProperty(alias T)
@@ -178,6 +184,10 @@ unittest {
 
     static assert(isFieldOrProperty!(Foo.success));
     static assert(!isFieldOrProperty!(Foo.failure));
+
+    // Make sure the struct behaves as expected
+    Foo foo;
+    assert( foo.failure(1) == 1 );
 }
 
 unittest {

--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -129,6 +129,25 @@ template isField(alias T)
     })();
 }
 
+unittest
+{
+    struct S {
+        @property auto property() { return 1.0; }
+        auto func() { return 1.0; }
+        auto tmplt()() {return 1.0; }
+        auto field = 0;
+    }
+
+    S s;
+    static assert( !isField!(s.property) );
+    static assert( !isField!(s.func) );
+    static assert( !isField!(s.tmplt) );
+    static assert( !isSomeFunction!(s.tmplt) );
+    static assert( __traits(isTemplate,s.tmplt) );
+
+    static assert( isField!(s.field) );
+}
+
 template isFieldOrProperty(alias T)
 {
     enum isFieldOrProperty = (function() {

--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -127,7 +127,7 @@ template isFieldOrProperty(alias T)
     enum isFieldOrProperty = (function() {
         static if (isSomeFunction!(T))
         {
-            return (functionAttributes!(T) & FunctionAttribute.property) != 0;
+            return (functionAttributes!(T) & FunctionAttribute.property);
         }
         else return true;
     })();
@@ -141,4 +141,10 @@ unittest {
 
     static assert(isFieldOrProperty!(Foo.success));
     static assert(!isFieldOrProperty!(Foo.failure));
+}
+
+unittest {
+    import std.typecons : Tuple;
+    // toString is template, should be ignored
+    static assert(!isFieldOrProperty!(Tuple!(int)(0).toString));
 }


### PR DESCRIPTION
isFieldOrProperty assumed that if member is not a function it is a trait. Now it turns out it can be a Template too, so we need to explicitly check for that.

The third commit is just a refactor, and could be ignored, but I though it could be generally to add an isField function. 

See blackedder/painlessjson#52 for some more info
