### PR TITLE
Fixing allPublicFields for classes

### DIFF
--- a/source/painlesstraits.d
+++ b/source/painlesstraits.d
@@ -194,17 +194,46 @@ private template publicMemberFilter(T, alias filter)
 {
     template Filter(alias memberName)
     {
-        static if (is(typeof(__traits(getMember, T.init, memberName))))
+        static if (is(T == class))
         {
-            static if (__traits(compiles, { enum Foo = __traits(getMember, T.init, memberName); }))
+            static if (is(typeof(__traits(getMember, T, memberName))))
             {
-                enum Filter = filter!(__traits(getMember, T.init, memberName));
+                static if (isSomeFunction!(__traits(getMember, T, memberName)))
+                {
+                    static if (!__traits(compiles, { auto foo = __traits(getMember, T, memberName); }))
+                    {
+                        enum Filter = filter!(__traits(getMember, T, memberName));
+                    }
+                    else
+                        enum Filter = false;
+                }
+                else
+                {
+                    static if (!__traits(compiles, { auto foo = &__traits(getMember, T, memberName); }))
+                    {
+                        enum Filter = filter!(__traits(getMember, T, memberName));
+                    }
+                    else
+                        enum Filter = false;
+                }
             }
             else
                 enum Filter = false;
         }
         else
-            enum Filter = false;
+        {
+            static if (is(typeof(__traits(getMember, T.init, memberName))))
+            {
+                static if (__traits(compiles, { enum Foo = __traits(getMember, T.init, memberName); }))
+                {
+                    enum Filter = filter!(__traits(getMember, T.init, memberName));
+                }
+                else
+                    enum Filter = false;
+            }
+            else
+                enum Filter = false;
+        }
     }
 }
 

--- a/test/publicmembers.d
+++ b/test/publicmembers.d
@@ -47,3 +47,51 @@ unittest {
     assert(i == 4);
     s.hello();
 }
+
+unittest {
+    class TestClass
+    {
+        int i = 5;
+        string str = "a";
+        long l;
+        private double b;
+        static ubyte s;
+
+        void foo()
+        {
+        }
+
+        int bar() @property
+        {
+            return i;
+        }
+
+        this(int j)
+        {
+            i = j;
+        }
+
+        void hello()()
+        {
+        }
+    }
+
+    alias members = allPublicFieldsOrProperties!TestClass;
+    static assert(members.length == 4);
+    static assert(members[0] == "i");
+    static assert(members[1] == "str");
+    static assert(members[2] == "l");
+    static assert(members[3] == "bar");
+
+    alias fields = allPublicFields!TestClass;
+    static assert(fields.length == 3);
+    static assert(fields[0] == "i");
+    static assert(fields[1] == "str");
+    static assert(fields[2] == "l");
+
+    TestClass s = new TestClass(4);
+    s.foo();
+    int i = s.bar();
+    assert(i == 4);
+    s.hello();
+}

--- a/test/publicmembers.d
+++ b/test/publicmembers.d
@@ -77,17 +77,35 @@ unittest {
     }
 
     alias members = allPublicFieldsOrProperties!TestClass;
-    static assert(members.length == 4);
-    static assert(members[0] == "i");
-    static assert(members[1] == "str");
-    static assert(members[2] == "l");
-    static assert(members[3] == "bar");
-
     alias fields = allPublicFields!TestClass;
-    static assert(fields.length == 3);
-    static assert(fields[0] == "i");
-    static assert(fields[1] == "str");
-    static assert(fields[2] == "l");
+    static if (__traits(compiles, __traits(isTemplate, TestClass.hello)))
+    {
+        static assert(members.length == 4);
+        static assert(members[0] == "i");
+        static assert(members[1] == "str");
+        static assert(members[2] == "l");
+        static assert(members[3] == "bar");
+
+        static assert(fields.length == 3);
+        static assert(fields[0] == "i");
+        static assert(fields[1] == "str");
+        static assert(fields[2] == "l");
+    }
+    else
+    {
+        static assert(members.length == 5);
+        static assert(members[0] == "i");
+        static assert(members[1] == "str");
+        static assert(members[2] == "l");
+        static assert(members[3] == "bar");
+        static assert(members[4] == "hello");
+
+        static assert(fields.length == 4);
+        static assert(fields[0] == "i");
+        static assert(fields[1] == "str");
+        static assert(fields[2] == "l");
+        static assert(fields[3] == "hello");
+    }
 
     TestClass s = new TestClass(4);
     s.foo();


### PR DESCRIPTION
That template didn't actually work for classes, it always returned an empty AliasSeq
